### PR TITLE
Feature/reduce user interaction

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -108,11 +108,13 @@ class ExternalModule extends AbstractExternalModule {
 		$sender = $project_contact_email ?: 'CTSI-REDCAP-SUPPORT-L@lists.ufl.edu';
 		$subject = $this->getSystemSetting("wups_subject");
 		$body = $this->getSystemSetting("wups_body");
+		$login_link = APP_PATH_WEBROOT_FULL;
 
 		$piping_pairs = [
 			'[username]' => $user_info['username'],
 			'[user_firstname]' => $user_info['user_firstname'],
 			'[user_lastname]' => $user_info['user_lastname'],
+			'[login_link]' => $login_link,
 			'[days_until_suspension]' => $user_info['days_until_suspension'],
 			'[suspension_date]' => $user_info['suspension_date']
 		];

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -20,9 +20,13 @@ class ExternalModule extends AbstractExternalModule {
      */
     function redcap_every_page_top($project_id)
     {
-    	if(defined('USERID') && !empty(USERID) && $_GET["wups_username"]){
-    		$this->extend_suspension_time($_GET["wups_username"]);
-    	}
+        $is_on_homepage = preg_match("/\/index.php\z/", PAGE);
+
+        if ($is_on_homepage) {
+            if(defined('USERID') && !empty(USERID)){
+                $this->extend_suspension_time(USERID);
+            }
+        }
     }
 
     function extend_suspension_time($username='')
@@ -39,13 +43,13 @@ class ExternalModule extends AbstractExternalModule {
 
 			db_query($sql);
 
-			$message = "Your account suspension time has been succesfully extended.";
-
 			// Logging event
 			Logging::logEvent($sql, "redcap_user_information", "MANAGE", $username, "username = '$username'", "Extend user suspension date.", "", "SYSTEM");
 		}
 
-		echo "<script type='text/javascript'>alert('$message');</script>";
+        if ($message) {
+            echo "<script type='text/javascript'>alert('$message');</script>";
+        }
     }
 
 	function warn_users_account_suspension_cron()
@@ -104,13 +108,11 @@ class ExternalModule extends AbstractExternalModule {
 		$sender = $project_contact_email ?: 'CTSI-REDCAP-SUPPORT-L@lists.ufl.edu';
 		$subject = $this->getSystemSetting("wups_subject");
 		$body = $this->getSystemSetting("wups_body");
-		$activation_link = APP_PATH_WEBROOT_FULL . "?wups_username=" . $user_info['username'];
 
 		$piping_pairs = [
 			'[username]' => $user_info['username'],
 			'[user_firstname]' => $user_info['user_firstname'],
 			'[user_lastname]' => $user_info['user_lastname'],
-			'[activation_link]' => $activation_link,
 			'[days_until_suspension]' => $user_info['days_until_suspension'],
 			'[suspension_date]' => $user_info['suspension_date']
 		];

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WUPS is dependent upon REDCap's normal _Auto-suspend users after period of inact
 
 ## Configuration
 
-The module is configurable at the system level to allow the subject line and body of the message to be customized. The message body supports parameter substitution like REDCap's data piping to allow messages to be customized with fields like `[username]`, `[user_firstname]`, `[user_lastname]`, `[activation_link]`, `[days_until_suspension]` and `[suspension_date]`. The `[activation_link]` is used to prevent account suspension.
+The module is configurable at the system level to allow the subject line and body of the message to be customized. The message body supports parameter substitution like REDCap's data piping to allow messages to be customized with fields like `[username]`, `[user_firstname]`, `[user_lastname]`, `[login_link]`, `[days_until_suspension]` and `[suspension_date]`. The `[login_link]` is the REDCap login page.
 
 ### Email Configuration Example
 
@@ -29,8 +29,8 @@ The module is configurable at the system level to allow the subject line and bod
         Dear [user_firstname] [user_lastname], <br><br>
 
         Your account will be suspended in [days_until_suspension] days on [suspension_date].
-        If you want to avoid account suspension, please go to
-        <a href="[activation_link]">REDCap account extension</a>. <br><br>
+        If you want to avoid account suspension, please log in to
+        <a href="[login_link]">your REDCap account</a>. <br><br>
 
         Regards,<br>
         REDCap Support Team.

--- a/config.json
+++ b/config.json
@@ -26,6 +26,11 @@
             "name": "Tiago Bember",
             "email": "tbembersimeao@ufl.edu",
             "institution": "University of Florida - CTSI"
+        },
+        {
+            "name": "Kyle Chesney",
+            "email": "kyle.chesney@ufl.edu",
+            "institution": "University of Florida - CTSI"
         }
     ],
     "system-settings" : [


### PR DESCRIPTION
Addresses issue #6 
User activity is updated upon visiting the REDCap homepage, a message is only shown in the event of an error, `activation_link` replaced with `login_link` which points to the REDCap home page