### PR TITLE
change the email body to rich text to preview HTML

### DIFF
--- a/config.json
+++ b/config.json
@@ -45,7 +45,7 @@
             "key": "wups_body",
             "name": "Email Body",
             "required": false,
-            "type": "textarea",
+            "type": "rich-text",
             "repeatable": false
         },
         {


### PR DESCRIPTION
Address issue #8  
Changes the type of the email body input from raw text input to `rich-text` (i.e. REDCap's stylized HTML input field) to allow users to preview the appearance of emails