### PR TITLE
stop calling ExternalModules class directly

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -7,7 +7,6 @@
 namespace SuspensionWarning\ExternalModule;
 
 use ExternalModules\AbstractExternalModule;
-use ExternalModules\ExternalModules;
 use REDCap;
 use Logging;
 
@@ -94,7 +93,7 @@ class ExternalModule extends AbstractExternalModule {
 					) as my_user_info
 					where '$suspend_users_inactive_days' - DATEDIFF(NOW(), user_last_date) = '$day';";
 
-			$q = ExternalModules::query($sql);
+			$q = $this->query($sql);
 
 			while ($row = db_fetch_assoc($q))
 			{


### PR DESCRIPTION
Addresses issue #19 by replacing the direct call to the` ExternalModules` class.

To test:

0. In a docker environment with no table users, first add table users via: https://github.com/ctsit/redcap_deployment/blob/master/deploy/files/test_with_table_based_authentication.sql
    - This can be done in [phpmyadmin](http://localhost/phpmyadmin/tbl_sql.php?db=redcap&table=redcap_auth).
    - Remember to change `,'my_salt_string',0,0` to `,'my_salt_string',1,0` on lines 19-23
1. Follow procedure as outlined in [this module's README.md](https://github.com/ctsit/warn_users_of_pending_suspension#developer-testing-techniques).

Module should be tested in REDCap version 9.6.3 as well as at least one lower version.